### PR TITLE
use english locale by default

### DIFF
--- a/src/main/java/co/bitshfted/xapps/zsync/ZsyncMake.java
+++ b/src/main/java/co/bitshfted/xapps/zsync/ZsyncMake.java
@@ -43,6 +43,7 @@ import java.security.MessageDigest;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.Locale;
 import java.util.TimeZone;
 
 import co.bitshfted.xapps.zsync.internal.util.ZsyncUtil;
@@ -61,7 +62,7 @@ public class ZsyncMake {
 
   @SuppressWarnings("serial")
   private static final SimpleDateFormat LAST_MODIFIED_TIME_FORMAT =
-      new SimpleDateFormat("EEE, dd MMMMM yyyy HH:mm:ss Z") {
+      new SimpleDateFormat("EEE, dd MMMMM yyyy HH:mm:ss Z", Locale.ENGLISH) {
         {
           this.setTimeZone(TimeZone.getTimeZone("GMT"));
         }

--- a/src/main/java/co/bitshfted/xapps/zsync/internal/Header.java
+++ b/src/main/java/co/bitshfted/xapps/zsync/internal/Header.java
@@ -35,6 +35,7 @@ import java.io.InputStreamReader;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Locale;
 
 public class Header {
 
@@ -122,7 +123,7 @@ public class Header {
         sha1 = value;
       } else if ("MTime".equals(name)) {
         try {
-          mtime = new SimpleDateFormat("EEE, dd MMMMM yyyy HH:mm:ss Z").parse(value);
+          mtime = new SimpleDateFormat("EEE, dd MMMMM yyyy HH:mm:ss Z", Locale.ENGLISH).parse(value);
         } catch (ParseException e) {
           throwInvalidHeaderValue(name, value);
         }


### PR DESCRIPTION
I'm using the zsync library in an Application and use the default locale from my computer.
My computer default locale is german, so the SimpleDateFormatter uses German but zsyncmake on linux uses english. Thats why i get an parse error.

Would be great if we use english as default locale.